### PR TITLE
tlt-2844: configure canvas external tool to use modules

### DIFF
--- a/mediasite/apimethods.py
+++ b/mediasite/apimethods.py
@@ -519,7 +519,7 @@ class MediasiteAPI:
 
     @staticmethod
     def get_mediasite_url(partial_url):
-        return settings.MEDIASITE_URL.format(partial_url)
+        return settings.MEDIASITE_API_URL.format(partial_url)
 
     @staticmethod
     def is_production():

--- a/mediasite_provisioning/settings/base.py
+++ b/mediasite_provisioning/settings/base.py
@@ -144,7 +144,11 @@ LOGGING_CONFIG = None
 ###################################################################
 
 MEDIASITE_API_KEY = SECURE_SETTINGS.get('mediasite_api_key')
-MEDIASITE_URL = SECURE_SETTINGS.get('mediasite_url')
+MEDIASITE_BASE_URL = SECURE_SETTINGS.get('mediasite_base_url')
+MEDIASITE_API_PATH = SECURE_SETTINGS.get('mediasite_api_path')
+MEDIASITE_API_URL = MEDIASITE_BASE_URL + MEDIASITE_API_PATH
+MEDIASITE_LTI_LAUNCH_PATH = SECURE_SETTINGS.get('mediasite_lti_launch_path')
+MEDIASITE_LTI_LAUNCH_URL = MEDIASITE_BASE_URL + MEDIASITE_LTI_LAUNCH_PATH
 CANVAS_URL = SECURE_SETTINGS.get('canvas_url')
 CANVAS_CLIENT_ID = SECURE_SETTINGS.get('canvas_client_id')
 CANVAS_CLIENT_SECRET = SECURE_SETTINGS.get('canvas_client_secret')

--- a/web/views.py
+++ b/web/views.py
@@ -219,7 +219,7 @@ def provision(request):
                 canvas_mediasite_module_item = canvas_api.create_mediasite_app_external_link(
                     course_id=course.id,
                     course_term=course.term.name,
-                    url=course_catalog.CatalogUrl,
+                    url=settings.MEDIASITE_LTI_LAUNCH_URL,
                     consumer_key=oath_consumer_key,
                     shared_secret=shared_secret)
 


### PR DESCRIPTION
Canvas external tool installation/configuration now uses module-based catalog resolution instead of direct catalog link.

Note that some environment/secure settings need to change for this update.

New settings:
```
'mediasite_base_url': 'https://dvsdev.mediasite.video.harvard.edu/mediasite/',
'mediasite_api_path': 'api/v1/{0}',
'mediasite_lti_launch_path': 'lti/catalog/',
```

Deprecated settings:
- `mediasite_url` is deprecated (can be removed).

This PR is against [TLT-2822](https://github.com/Harvard-University-iCommons/MediasiteProvisioning/tree/task/elliottyates/tlt-2844/lti_tool_install_using_modules), but ultimately should be merged into develop instead of that branch; the PR is done against that branch to make it easier to see what's changed.

Note: settings changes to environment setting (YAML) files in AWS will have a slightly different format, e.g.:
```
    mediasite_base_url: 'https://dvsdev.mediasite.video.harvard.edu/mediasite/'
    mediasite_api_path: 'api/v1/{0}'
    mediasite_lti_launch_path: 'lti/catalog/'
```