### PR TITLE
tlt-2859: search form - account selection restricted to valid accounts

### DIFF
--- a/web/forms.py
+++ b/web/forms.py
@@ -19,28 +19,36 @@ class IndexForm(forms.Form):
         canvas_api = CanvasAPI(user=self.user)
         accounts = canvas_api.get_accounts_for_current_user()
         if accounts:
-            for account in accounts:
-                try:
-                    school = School.objects.get(canvas_id=account.id)
-                    # update school name in case it has changed in Canvas
-                    school.name = account.name
-                    school.save()
-                    if self._is_valid_school_account(school):
-                        account_choice = (account.id, account.name)
-                        account_choices.add(account_choice)
-                except ObjectDoesNotExist:
-                    # do nothing since we initialized school above
-                    pass
+            if [a for a in accounts if a.id == 1]:
+                # user has a root account permission, allow all schools in
+                # dropdown
+                schools = School.objects.all()
+                valid_schools = [(s.canvas_id, s.name) for s in schools
+                                 if self._is_valid_school_account(s)]
+                account_choices = set(valid_schools)
+            else:
+                for account in accounts:
+                    try:
+                        school = School.objects.get(canvas_id=account.id)
+                        # update school name in case it has changed in Canvas
+                        school.name = account.name
+                        school.save()
+                        if self._is_valid_school_account(school):
+                            account_choice = (account.id, account.name)
+                            account_choices.add(account_choice)
+                    except ObjectDoesNotExist:
+                        # do nothing since we initialized school above
+                        pass
 
         self.fields['accounts'] = forms.ChoiceField(choices=account_choices,
                                                     required=True)
 
     @staticmethod
     def _is_valid_school_account(school):
-        # a school is a valid choice in the form dropdown if it has all the
+        # A school is a valid choice in the form dropdown if it has all the
         # information required to reliably provision a lecture video Canvas
-        # integration
-        return school.canvas_id and \
-               school.mediasite_root_folder and \
-               school.consumer_key and \
-               school.shared_secret
+        # integration (consumer key and secret can fall back to values in
+        # SETTINGS if needed, but canvas_id and mediasite_root_folder should be
+        # specified for each school to be able to query canvas and create the
+        # mediasite folder structure).
+        return school.canvas_id and school.mediasite_root_folder

--- a/web/forms.py
+++ b/web/forms.py
@@ -16,39 +16,28 @@ class IndexForm(forms.Form):
         super(IndexForm, self).__init__(*args, **kwargs)
 
         account_choices = set()
-        canvas_api = CanvasAPI(user=self.user)
-        accounts = canvas_api.get_accounts_for_current_user()
-        if accounts:
-            if [a for a in accounts if a.id == 1]:
-                # user has a root account permission, allow all schools in
-                # dropdown
-                schools = School.objects.all()
-                valid_schools = [(s.canvas_id, s.name) for s in schools
-                                 if self._is_valid_school_account(s)]
-                account_choices = set(valid_schools)
-            else:
-                for account in accounts:
-                    try:
-                        school = School.objects.get(canvas_id=account.id)
-                        # update school name in case it has changed in Canvas
-                        school.name = account.name
-                        school.save()
-                        if self._is_valid_school_account(school):
-                            account_choice = (account.id, account.name)
-                            account_choices.add(account_choice)
-                    except ObjectDoesNotExist:
-                        # do nothing since we initialized school above
-                        pass
+        if self.user.is_staff:
+            # user should be able to provision for any school
+            schools = School.objects.all()
+            valid_schools = [(s.canvas_id, s.name) for s in schools
+                             if s.can_be_provisioned]
+            account_choices = set(valid_schools)
+        else:
+            canvas_api = CanvasAPI(user=self.user)
+            accounts = canvas_api.get_accounts_for_current_user()
+            for account in accounts:
+                try:
+                    school = School.objects.get(canvas_id=account.id)
+                    # update school name in case it has changed in Canvas
+                    school.name = account.name
+                    school.save()
+                    if school.can_be_provisioned:
+                        account_choice = (account.id, account.name)
+                        account_choices.add(account_choice)
+                except ObjectDoesNotExist:
+                    # do nothing since we initialized school above
+                    pass
 
-        self.fields['accounts'] = forms.ChoiceField(choices=account_choices,
+        sorted_choices = sorted(account_choices, key=lambda a: a[1])
+        self.fields['accounts'] = forms.ChoiceField(choices=sorted_choices,
                                                     required=True)
-
-    @staticmethod
-    def _is_valid_school_account(school):
-        # A school is a valid choice in the form dropdown if it has all the
-        # information required to reliably provision a lecture video Canvas
-        # integration (consumer key and secret can fall back to values in
-        # SETTINGS if needed, but canvas_id and mediasite_root_folder should be
-        # specified for each school to be able to query canvas and create the
-        # mediasite folder structure).
-        return school.canvas_id and school.mediasite_root_folder

--- a/web/forms.py
+++ b/web/forms.py
@@ -1,37 +1,46 @@
 from django import forms
 from django.core.exceptions import ObjectDoesNotExist
-from canvas.apimethods import CanvasAPI
+
 from .models import School
+from canvas.apimethods import CanvasAPI
+
 
 class IndexForm(forms.Form):
     accounts = None
-    search = forms.CharField(min_length=3, widget=forms.TextInput(attrs={'placeholder': 'Please enter at least 3 characters'}))
+    search = forms.CharField(min_length=3, widget=forms.TextInput(
+        attrs={'placeholder': 'Please enter at least 3 characters'}))
     search_results = ()
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop('user')
         super(IndexForm, self).__init__(*args, **kwargs)
 
-        account_choices = list()
+        account_choices = set()
         canvas_api = CanvasAPI(user=self.user)
         accounts = canvas_api.get_accounts_for_current_user()
         if accounts:
             for account in accounts:
-                account_choice = ((account.id, account.name))
-                account_choices.append(account_choice)
-                # we also save/update account information
-                school = School(canvas_id=account.id, name=account.name)
                 try:
-                    school = School.objects.get(canvas_id = account.id)
+                    school = School.objects.get(canvas_id=account.id)
+                    # update school name in case it has changed in Canvas
                     school.name = account.name
+                    school.save()
+                    if self._is_valid_school_account(school):
+                        account_choice = (account.id, account.name)
+                        account_choices.add(account_choice)
                 except ObjectDoesNotExist:
                     # do nothing since we initialized school above
                     pass
-                school.save()
 
-        self.fields['accounts'] = forms.ChoiceField(choices=account_choices, required=True)
+        self.fields['accounts'] = forms.ChoiceField(choices=account_choices,
+                                                    required=True)
 
-
-
-
-
+    @staticmethod
+    def _is_valid_school_account(school):
+        # a school is a valid choice in the form dropdown if it has all the
+        # information required to reliably provision a lecture video Canvas
+        # integration
+        return school.canvas_id and \
+               school.mediasite_root_folder and \
+               school.consumer_key and \
+               school.shared_secret

--- a/web/migrations/0007_mediasite_root_folder_required_20161019_1943.py
+++ b/web/migrations/0007_mediasite_root_folder_required_20161019_1943.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('web', '0006_auto_20160604_0814'),
+    ]
+
+    operations = [
+        # Note there are NO defaults set, so manual cleanup of the existing
+        # records in the table must be performed to remove any records with
+        # blank mediasite_root_folder fields; otherwise this migration will
+        # fail with a django.db.utils.IntegrityError.
+        migrations.AlterField(
+            model_name='school',
+            name='mediasite_root_folder',
+            field=models.TextField(),
+        ),
+    ]

--- a/web/migrations/0007_mediasite_root_folder_required_20161019_1943.py
+++ b/web/migrations/0007_mediasite_root_folder_required_20161019_1943.py
@@ -3,6 +3,16 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
+DEFAULT = 'None'
+
+
+def give_existing_records_sane_defaults(apps, schema_editor):
+    # Clean up any records with blank strings. Nulls are handled by AlterField.
+    school_class = apps.get_model('web', 'School')
+    school_class.objects.select_for_update()\
+        .filter(mediasite_root_folder='')\
+        .update(mediasite_root_folder=DEFAULT)
+
 
 class Migration(migrations.Migration):
 
@@ -11,13 +21,31 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Note there are NO defaults set, so manual cleanup of the existing
-        # records in the table must be performed to remove any records with
-        # blank mediasite_root_folder fields; otherwise this migration will
-        # fail with a django.db.utils.IntegrityError.
+        # The AlterField migration below doesn't automatically convert blank
+        # strings saved in the DB to 'None' (it only handles null fields), so
+        # we need to clean these fields up manually.
+        migrations.RunPython(
+            code=give_existing_records_sane_defaults,
+            reverse_code=migrations.RunPython.noop,
+        ),
+        # Note there are NO defaults set in the actual model, because we don't
+        # want users or code to add web_school records without specifying a
+        # root folder, so this migration performs cleanup of the existing
+        # records in the table to ensure there are no blank
+        # mediasite_root_folder fields, without persisting a default in the
+        # model itself. The user is responsible for fixing the
+        # data so it makes sense (i.e. so that integrations which shouldn't be
+        # using 'None' as the root folder are updated manually or removed from
+        # the database entirely); the timing of this manual cleanup can be
+        # independent of the actual migration.
         migrations.AlterField(
             model_name='school',
             name='mediasite_root_folder',
-            field=models.TextField(),
+            field=models.TextField(
+                null=False,  # do not allow empty field (DB-level constraint)
+                blank=False,  # do not allow empty strings in field
+                              # (Django only; not a DB-level constraint)
+                default=DEFAULT),  # temporary default for migration only
+            preserve_default=False  # default is not permanent in model
         ),
     ]

--- a/web/models.py
+++ b/web/models.py
@@ -1,5 +1,6 @@
-from django.db import models
 from django.contrib.auth.models import User
+from django.db import models
+
 
 class School(models.Model):
     canvas_id = models.TextField()
@@ -11,9 +12,21 @@ class School(models.Model):
     catalog_show_time = models.BooleanField(default=False, null=False)
     catalog_items_per_page = models.IntegerField(blank=100, null=100)
 
+    @property
+    def can_be_provisioned(self):
+        # A school is a valid choice in the form dropdown if it has all the
+        # information required to reliably provision a lecture video Canvas
+        # integration (consumer key and secret can fall back to values in
+        # SETTINGS if needed, but canvas_id and mediasite_root_folder should be
+        # specified for each school to be able to query canvas and create the
+        # mediasite folder structure).
+        return bool(self.canvas_id) and bool(self.mediasite_root_folder)
+
+
 class APIUser(models.Model):
     user = models.OneToOneField(User)
     canvas_api_key = models.TextField()
+
 
 class Log(models.Model):
     username = models.TextField(blank=True, null=True)

--- a/web/models.py
+++ b/web/models.py
@@ -5,7 +5,7 @@ from django.db import models
 class School(models.Model):
     canvas_id = models.TextField()
     name = models.TextField()
-    mediasite_root_folder = models.TextField()
+    mediasite_root_folder = models.TextField(blank=False, null=False)
     consumer_key = models.TextField(blank=True, null=True)
     shared_secret = models.TextField(blank=True, null=True)
     catalog_show_date = models.BooleanField(default=False, null=False)

--- a/web/models.py
+++ b/web/models.py
@@ -5,22 +5,12 @@ from django.db import models
 class School(models.Model):
     canvas_id = models.TextField()
     name = models.TextField()
-    mediasite_root_folder = models.TextField(blank=True, null=True)
+    mediasite_root_folder = models.TextField()
     consumer_key = models.TextField(blank=True, null=True)
     shared_secret = models.TextField(blank=True, null=True)
     catalog_show_date = models.BooleanField(default=False, null=False)
     catalog_show_time = models.BooleanField(default=False, null=False)
     catalog_items_per_page = models.IntegerField(blank=100, null=100)
-
-    @property
-    def can_be_provisioned(self):
-        # A school is a valid choice in the form dropdown if it has all the
-        # information required to reliably provision a lecture video Canvas
-        # integration (consumer key and secret can fall back to values in
-        # SETTINGS if needed, but canvas_id and mediasite_root_folder should be
-        # specified for each school to be able to query canvas and create the
-        # mediasite folder structure).
-        return bool(self.canvas_id) and bool(self.mediasite_root_folder)
 
 
 class APIUser(models.Model):


### PR DESCRIPTION
Canvas account list dropdown on search form now displays a de-duplicated list of accounts for:
- all records in the web_school table, if the user is a staff member; or,
- all records in the web_school table that the user also has a Canvas account permission for, otherwise.

The web_school records must have a canvas ID and root folder defined now (previously, root folder was optional). (The consumer key and secret can fall back on the tool's default setup, as the LTI config profiles in mediasite can be generic enough to support multiple schools, as long as the root folder and canvas ID are specified correctly for that school so that the provisioner can do its thing.)

This fixes:
- duplicates should no longer appear in the account dropdown; 
- accounts are sorted in the dropdown; and,
- users with staff permissions in the tool will see all (valid LTI-configured) schools in the list (since the 'root account search' should no longer be available to them).

This can be tested at: https://mediasite-provisioning.dev.tlt.harvard.edu/

Things to check in the DB as this moves through the environments:
- This will require cleanup of the `web_school` table: rows for which we do _not_ want to be able to search and provision should be removed completely (e.g. `canvas_id=1`). **This can be done before or after the migration. Rows without a value for `mediasite_root_folder` will be given a one-time default of `"None"`; these can be cleaned up after, if needed.** Rows without a consumer key and secret are also fine, but we should review that the default LTI config (currently specified by `settings.OAUTH_CONSUMER_KEY`) will work as expected for that school.
- We should ensure that #uw-service-team tool users are flagged as staff in the tool's `auth_user` table, so that they can (1) provision courses in any accounts e.g. in response to tickets or for testing, and (2) update `web_school` records and user `staff` permissions.