### PR TITLE
Task/sapnamysore/tlt 2856/fix folder structure

### DIFF
--- a/canvas/apimodels.py
+++ b/canvas/apimodels.py
@@ -99,10 +99,23 @@ class Course(BaseSerializedModel):
     @staticmethod
     def get_year_from_term(term):
         year = None
-        if hasattr(term, 'sis_term_id'):
-            if term.sis_term_id:
+
+        # If it's an Ongoing term, do not set the year explicitly(TLT-2856)
+        if term.name.lower()== 'ongoing':
+            return year
+
+        try:
+            if hasattr(term, 'sis_term_id'):
                 start_year = int(float(term.sis_term_id[:4]))
                 return '{0}-{1}'.format(start_year, start_year + 1)
+            elif term.name:
+                #If the user doesn't see the sis_term_id attribute, use the
+                # term name to deduce the year
+                start_year = int(float(term.name[:4]))
+                return '{0}-{1}'.format(start_year, start_year + 1)
+        except:
+            return year
+
 
     @staticmethod
     def get_year_from_start_date(year_start_at):

--- a/canvas/apimodels.py
+++ b/canvas/apimodels.py
@@ -114,6 +114,7 @@ class Course(BaseSerializedModel):
                 start_year = int(float(term.name[:4]))
                 return '{0}-{1}'.format(start_year, start_year + 1)
         except:
+            # Return None for poorly formatted terms
             return year
 
 

--- a/canvas/apimodels.py
+++ b/canvas/apimodels.py
@@ -100,17 +100,17 @@ class Course(BaseSerializedModel):
     def get_year_from_term(term):
         year = None
 
-        # If it's an Ongoing term, do not set the year explicitly(TLT-2856)
+        # If it's an Ongoing term, do not explicitly extract the year(TLT-2856)
+        #: do not display a year in search results for Ongoing courses
         if term.name.lower()== 'ongoing':
             return year
-
         try:
             if hasattr(term, 'sis_term_id'):
                 start_year = int(float(term.sis_term_id[:4]))
                 return '{0}-{1}'.format(start_year, start_year + 1)
             elif term.name:
-                #If the user doesn't see the sis_term_id attribute, use the
-                # term name to deduce the year
+                #If the user doesn't see the sis_term_id attribute(due to the
+                #  users' Canvas permissions), use the term name to deduce the year
                 start_year = int(float(term.name[:4]))
                 return '{0}-{1}'.format(start_year, start_year + 1)
         except:

--- a/web/views.py
+++ b/web/views.py
@@ -117,9 +117,9 @@ def provision(request):
             if root_folder is not None:
 
                 if term.lower()== 'ongoing':
-                    # If it's an 'Ongoing' term, do not create a folder for the
-                    # year, move onto the term folder(essentially collapsing the
-                    #  folder structure).(TLT-2856)
+                    # First check for Ongoing terms. For such terms, do not
+                    # create a folder for the year, move onto the term folder
+                    # (essentially collapsing the folder structure).(TLT-2856)
                     term_folder = MediasiteAPI.get_or_create_folder(name=term, parent_folder_id=root_folder.Id)
                 elif year == 'None':
                     #If the year is not set, raise an error

--- a/web/views.py
+++ b/web/views.py
@@ -115,15 +115,27 @@ def provision(request):
             course_folder = None
             root_folder = MediasiteAPI.get_or_create_folder(name=mediasite_root_folder, parent_folder_id=None)
             if root_folder is not None:
-                year_folder = MediasiteAPI.get_or_create_folder(name=year, parent_folder_id=root_folder.Id)
-                if year_folder is not None:
-                    term_folder = MediasiteAPI.get_or_create_folder(name=term, parent_folder_id=year_folder.Id)
-                    if term_folder is not None:
-                        course_folder = MediasiteAPI.get_or_create_folder(name=course_long_name,
-                                                                          parent_folder_id=term_folder.Id,
-                                                                          alternate_search_term=course.sis_course_id,
-                                                                          is_copy_destination=True,
-                                                                          is_shared=True)
+
+                if term.lower()== 'ongoing':
+                    # If it's an 'Ongoing' term, do not create a folder for the
+                    # year, move onto the term(essentially collapsing the folder
+                    #  structure).(TLT-2856)
+                    term_folder = MediasiteAPI.get_or_create_folder(name=term, parent_folder_id=root_folder.Id)
+                elif year == 'None':
+                    #If the year is not set, raise an error
+                    raise Exception('Sorry, there was an error provisioning this'
+                                    ' course. Please contact video support.')
+                else:
+                    year_folder = MediasiteAPI.get_or_create_folder(name=year, parent_folder_id=root_folder.Id)
+                    if year_folder is not None:
+                        term_folder = MediasiteAPI.get_or_create_folder(name=term, parent_folder_id=year_folder.Id)
+
+                if term_folder is not None:
+                    course_folder = MediasiteAPI.get_or_create_folder(name=course_long_name,
+                                                                      parent_folder_id=term_folder.Id,
+                                                                      alternate_search_term=course.sis_course_id,
+                                                                      is_copy_destination=True,
+                                                                      is_shared=True)
 
             if course_folder is not None:
                 # create course catalog, with course instance id to ensure uniqueness

--- a/web/views.py
+++ b/web/views.py
@@ -118,13 +118,13 @@ def provision(request):
 
                 if term.lower()== 'ongoing':
                     # If it's an 'Ongoing' term, do not create a folder for the
-                    # year, move onto the term(essentially collapsing the folder
-                    #  structure).(TLT-2856)
+                    # year, move onto the term folder(essentially collapsing the
+                    #  folder structure).(TLT-2856)
                     term_folder = MediasiteAPI.get_or_create_folder(name=term, parent_folder_id=root_folder.Id)
                 elif year == 'None':
                     #If the year is not set, raise an error
                     raise Exception('Sorry, there was an error provisioning this'
-                                    ' course. Please contact video support.')
+                                    ' course. Please contact video-support@harvard.edu')
                 else:
                     year_folder = MediasiteAPI.get_or_create_folder(name=year, parent_folder_id=root_folder.Id)
                     if year_folder is not None:


### PR DESCRIPTION
Changes for https://jira.huit.harvard.edu/browse/TLT-2856

1. If users doesn't have the right account level permission in Canvas to 'Read SIS data' the 'None' folder gets created as Canvas API calls do not include the Term's year metadata. Modified the logic to extract it from Term Name. As a result:
a) The courses in the Search results which did not display the correct 'Year' in it's column(showed None), now display the correct year.
b). The courses that were provisioned by such users used to be created under a 'None' year folder. That's fixed to correctly be provisioned under the correct year folder.

2. If the course is in an 'Ongoing' term,:
a)per the note above,do not create a folder for year(1900-1901), move onto the term folder(essentially collapsing the folder structure).
b) Instead of displaying Year 1900-1901, display None under 'Year) for Ongoing courses.

3. If there is bad term data(ex: Ongoing-x) or if we are unable to extract year info
a) display None for 'Year' in search results
b) Prevent provisioning and display the following message to user: "Sorry, there was an error provisioning this course. Please contact video-support@harvard.edu"


Testing info:
1.  For Ongoing courses, tested that a GSE course 'Sapna test course7 ( ILE-sap7 )' is correctly being created under the new 'Ongoing' folder structure 
2. Setup Isites test30 on dev to reproduce this issue. 
 Tested that 'RJtest 2493 ' is not being created under a 'None' folder but under GSE's '2014-2015 Summer' folder instead.
