### PR TITLE
Feature/search mediasite api on sis course

### DIFF
--- a/mediasite/apimethods.py
+++ b/mediasite/apimethods.py
@@ -54,6 +54,7 @@ class MediasiteServiceException(Exception):
                     pass
                 return error
 
+
 class MediasiteAPI:
     VIEW_ONLY_PERMISSION_FLAG = 4
     READ_ONLY_PERMISSION_FLAG = 5
@@ -71,18 +72,17 @@ class MediasiteAPI:
     def get_root_folder_id():
         if MediasiteAPI._root_folder_id is None:
             url = 'Home'
-            json =  MediasiteAPI.get_mediasite_request_json(url)
+            json = MediasiteAPI.get_mediasite_request_json(url)
             serializer = HomeSerializer(data=json)
             if serializer.is_valid(raise_exception=True):
                 MediasiteAPI._root_folder_id = Home(**serializer.validated_data).RootFolderId
         return MediasiteAPI._root_folder_id
 
     @staticmethod
-    def get_folder(name, parent_folder_id, alternative_search_term=None):
-        # Search on the name being passed in, unless an alternative is provided
-        search_term = name
-        if alternative_search_term is not None:
-            search_term = alternative_search_term
+    def get_folder(name, parent_folder_id, search_term=None):
+        # Search on the name being passed in, unless a search_term is provided
+        if search_term is None:
+            search_term = name
 
         folders = MediasiteAPI.get_folders(search_term, parent_folder_id)
         folder = next((f for f in folders if f.Name == name), None)
@@ -130,11 +130,11 @@ class MediasiteAPI:
             errors = serializer.errors
 
     @staticmethod
-    def get_or_create_folder(name, parent_folder_id, alternate_search_term=None, is_copy_destination=False, is_shared=False):
+    def get_or_create_folder(name, parent_folder_id, search_term=None, is_copy_destination=False, is_shared=False):
         if parent_folder_id is None:
             parent_folder_id = MediasiteAPI.get_root_folder_id()
         if parent_folder_id is not None:
-            folder = MediasiteAPI.get_folder(name, parent_folder_id, alternate_search_term)
+            folder = MediasiteAPI.get_folder(name, parent_folder_id, search_term)
             if not folder:
                 folder = MediasiteAPI.create_folder(name, parent_folder_id, is_copy_destination, is_shared)
         return folder
@@ -143,20 +143,19 @@ class MediasiteAPI:
     # Catalogs
     ######################################################
     @staticmethod
-    def get_or_create_catalog(friendly_name, catalog_name, course_folder_id, alternative_search_term=None):
-        catalog = MediasiteAPI.get_catalog(catalog_name, course_folder_id, alternative_search_term)
+    def get_or_create_catalog(friendly_name, catalog_name, course_folder_id, search_term=None):
+        catalog = MediasiteAPI.get_catalog(catalog_name, course_folder_id, search_term)
         if catalog is None:
             catalog = MediasiteAPI.create_catalog(friendly_name, catalog_name, course_folder_id)
         return catalog
 
     @staticmethod
-    def get_catalog(name, course_folder_id, alternative_search_term=None):
+    def get_catalog(name, course_folder_id, search_term=None):
         """ See oDAta note above in `get_folders` method """
 
-        # Search on the name being passed in, unless an alternative is provided
-        search_term = name
-        if alternative_search_term is not None:
-            search_term = alternative_search_term
+        # Search on the name being passed in, unless a search_term is provided
+        if search_term is None:
+            search_term = name
 
         catalogs = MediasiteAPI.get_catalogs(search_term)
         catalog = next((c for c in catalogs if c.LinkedFolderId == course_folder_id), None)

--- a/web/views.py
+++ b/web/views.py
@@ -121,7 +121,7 @@ def provision(request):
                     if term_folder is not None:
                         course_folder = MediasiteAPI.get_or_create_folder(name=course_long_name,
                                                                           parent_folder_id=term_folder.Id,
-                                                                          alternate_search_term=course.sis_course_id,
+                                                                          search_term=course.sis_course_id,
                                                                           is_copy_destination=True,
                                                                           is_shared=True)
 
@@ -135,7 +135,7 @@ def provision(request):
                 course_catalog = MediasiteAPI.get_or_create_catalog(friendly_name=catalog_display_name,
                                                                     catalog_name=course_long_name,
                                                                     course_folder_id=course_folder.Id,
-                                                                    alternative_search_term=course.course_code)
+                                                                    search_term=course.sis_course_id)
                 if course_catalog is not None:
                     MediasiteAPI.set_catalog_settings(course_catalog.Id, catalog_show_date, catalog_show_time, catalog_items_per_page)
 

--- a/web/views.py
+++ b/web/views.py
@@ -160,6 +160,15 @@ def provision(request):
                 # get existing permissions for course folder
                 folder_permissions = MediasiteAPI.get_folder_permissions(course_folder.Id)
 
+                # NOTE: The following calls to `update_folder_permissions` do
+                # NOT actually call out to the Mediasite API.  Instead, they
+                # build up the `folder_permissions` Python list model.  The
+                # ultimate call to `assign_permissions_to_folder` makes the
+                # API call that passes up the list of permissions to Mediasite.
+                # As a future TBD, we should consider taking the
+                # `update_folder_permission` method out of the `apimethods`
+                # module since it's not actually an API call.
+
                 # create student role if it does not exist, and update (in memory) the permission set for the folder
                 directory_entry = "{0}@{1}".format(course.sis_course_id, oath_consumer_key)
                 course_role = MediasiteAPI.get_or_create_role(role_name=course_long_name, directory_entry=directory_entry)


### PR DESCRIPTION
This PR modifies the `search_term` logic when making Mediasite API calls that determine whether a given folder or catalog exists.  Prior to this change, the catalog or folder name was used as the primary basis for searching on catalogs and folders respectively.  GIven the oData quirks noted as part of this PR in the corresponding methods, the logic has been updated to use the (formerly named) alternative search term as the primary search term over the name if it's given.  In the case of course folder or catalog creation, the course sis id is part of the name, so searching on this id instead of the full name should provide more consistent search results.

Also included is some minor PEP-8 cleanup, as well as a comment about how the API is used when folder permissions are established.

@elliottyates 
@sapnamysore 