### PR TITLE
TLT-2873: Unicode course title support

### DIFF
--- a/canvas/apimethods.py
+++ b/canvas/apimethods.py
@@ -1,16 +1,34 @@
-import requests
+from __future__ import unicode_literals
+
 import enum
 import json
-import sys
 import logging
+from operator import attrgetter
+
 
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from operator import itemgetter, attrgetter, methodcaller
-from rest_framework.exceptions import APIException
-from .serializer import AccountSerializer, CourseSerializer, EnrollmentSerializer, UserSerializer, ModuleSerializer
-from .serializer import ModuleItemSerializer, ExternalToolSerializer, LinkSerializer
-from .apimodels import Course, Module, ModuleItem, Account, User, Enrollment, ExternalTool, SearchResults, Term, Link
+import requests
+
+from .apimodels import (
+    Account,
+    Course,
+    Enrollment,
+    ExternalTool,
+    Link,
+    Module,
+    ModuleItem,
+    SearchResults,
+    User)
+from .serializer import (
+    AccountSerializer,
+    CourseSerializer,
+    EnrollmentSerializer,
+    ExternalToolSerializer,
+    LinkSerializer,
+    ModuleItemSerializer,
+    ModuleSerializer,
+    UserSerializer)
 
 logger = logging.getLogger(__name__)
 

--- a/mediasite/apimethods.py
+++ b/mediasite/apimethods.py
@@ -1,21 +1,14 @@
-import requests
+from __future__ import unicode_literals
+
 import json
-import uuid
-import urllib
 import logging
 import time
+import uuid
 
 from django.conf import settings
+import requests
 from requests.auth import HTTPBasicAuth
 
-from .serializer import (
-    CatalogSerializer,
-    FolderSerializer,
-    HomeSerializer,
-    ModuleSerializer,
-    ResourcePermissionSerializer,
-    RoleSerializer,
-    UserProfileSerializer, )
 from .apimodels import (
     AccessControl,
     Catalog,
@@ -26,6 +19,14 @@ from .apimodels import (
     ResourcePermission,
     Role,
     UserProfile, )
+from .serializer import (
+    CatalogSerializer,
+    FolderSerializer,
+    HomeSerializer,
+    ModuleSerializer,
+    ResourcePermissionSerializer,
+    RoleSerializer,
+    UserProfileSerializer, )
 from .utils import odata_encode_str
 
 logger = logging.getLogger(__name__)

--- a/mediasite/tests.py
+++ b/mediasite/tests.py
@@ -1,6 +1,9 @@
+from __future__ import unicode_literals
+
 from django.test import TestCase
 from .apimethods import MediasiteAPI
-from .apimodels import Role, Folder
+from .apimodels import Role
+
 
 # Create your tests here.
 class MediasiteTestCase(TestCase):

--- a/mediasite/utils.py
+++ b/mediasite/utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from requests.compat import quote_plus
 
 
@@ -5,4 +7,5 @@ def odata_encode_str(s):
     """ String eq comparison in OData requires special characters
     to be escaped, like &. ALSO, single quotes need to be doubled up,
     so we do that before encoding.  """
-    return quote_plus(s.replace("'", "''"))
+    s = s.replace("'", "''")
+    return quote_plus(s.encode('utf8'))

--- a/web/views.py
+++ b/web/views.py
@@ -142,8 +142,12 @@ def provision(request):
                 # create course catalog, with course instance id to ensure uniqueness
                 catalog_display_name = '{0}-{1}-{2}-{3}-lecture-video'\
                     .format(mediasite_root_folder, term, course.course_code, course.sis_course_id)
-                # this is needed because a bug in Mediasite allows for the creation of a URL with potentially
-                # dangerous strings in it. we strip out the characters that we know might create that type of URL
+                # This is needed because a bug in Mediasite allows for the
+                # creation of a URL with potentially dangerous strings in it.
+                # we strip out the characters that we know might create that
+                # type of URL. Unicode strings require a translation map of
+                # code points to replacement characters, see
+                # https://docs.python.org/2/library/stdtypes.html#str.translate
                 catalog_display_name = catalog_display_name.translate(
                     {ord(c): None for c in '<>*%:&\\ '})
                 course_catalog = MediasiteAPI.get_or_create_catalog(friendly_name=catalog_display_name,

--- a/web/views.py
+++ b/web/views.py
@@ -1,22 +1,19 @@
-from django.shortcuts import render, get_object_or_404
-from django.views import generic
-from django.shortcuts import redirect
+from __future__ import unicode_literals
+
+import logging
+
+from django.shortcuts import redirect, render
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
-from django.http import HttpResponseServerError, HttpResponse
 from django.contrib.auth.models import User
 from django.core.exceptions import ObjectDoesNotExist
-import string
-import sys
-import json
-import logging
-from datetime import datetime
-from canvas.apimethods import CanvasAPI, CanvasServiceException
-from canvas.apimodels import Term, SearchResults
-from mediasite.apimethods import MediasiteAPI, MediasiteServiceException
-from mediasite.apimodels import UserProfile, Role
+from django.http import HttpResponse, HttpResponseServerError
+
 from .forms import IndexForm
-from .models import School, Log, APIUser
+from .models import APIUser, School
+from canvas.apimethods import CanvasAPI, CanvasServiceException
+from mediasite.apimethods import MediasiteAPI, MediasiteServiceException
+from mediasite.apimodels import Role, UserProfile
 
 logger = logging.getLogger(__name__)
 
@@ -147,7 +144,8 @@ def provision(request):
                     .format(mediasite_root_folder, term, course.course_code, course.sis_course_id)
                 # this is needed because a bug in Mediasite allows for the creation of a URL with potentially
                 # dangerous strings in it. we strip out the characters that we know might create that type of URL
-                catalog_display_name = catalog_display_name.translate(None, '<>*%:&\\ ')
+                catalog_display_name = catalog_display_name.translate(
+                    {ord(c): None for c in '<>*%:&\\ '})
                 course_catalog = MediasiteAPI.get_or_create_catalog(friendly_name=catalog_display_name,
                                                                     catalog_name=course_long_name,
                                                                     course_folder_id=course_folder.Id,


### PR DESCRIPTION
Courses with Unicode characters in their titles are now provisionable; folder and catalog in Mediasite will correctly display these characters. https://jira.huit.harvard.edu/browse/TLT-2873.

This supersedes #7.
Test site: GSE - CIID 377696.

This has been tested
(1) from scratch; and,
(2) in the case where the folders, catalog, modules, and roles exist already.

If any of the intermediate resources doesn't exist, it should still work, but I have had problems testing these scenarios because it appears there is some cached information I can't control or view on dvsdev if you delete, for instance, a catalog, then try to re-provision with identical information shortly thereafter. There's a support ticket open with Sonic Foundry to track this issue: https://support.sonicfoundry.com/Account/Case/00066385.